### PR TITLE
Reduce line spacing in author information

### DIFF
--- a/relai_poster_template.typ
+++ b/relai_poster_template.typ
@@ -84,6 +84,7 @@
             gutter: 10mm,
             align: horizon + center,
             ..authors.map(author => [
+                #set text(top-edge: 0em, bottom-edge: 0em)
                 #text(author.name, size: 20pt)\
                 #text(author.affiliation, size: 15pt)\
                 #text(author.email, size: 15pt)


### PR DESCRIPTION
Hey Ole, thanks for the nice template! 😉

With longer university names (e.g. University of ...) and multiple authors, I've noticed a lot of line spacing once the university name leads to a line break. The following change looks good on my end, so I thought I'd contribute it, but maybe there's a neater way of achieving it.. line spacing seems to behave oddly in typst.